### PR TITLE
Add Chromebrew/OrderedCompatibility cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -5,3 +5,8 @@ Chromebrew/CompatibilityAll:
   Description: "This cop checks for compatibility values that can be replaced by 'all'."
   Enabled: true
   VersionAdded: '0.0.1'
+
+Chromebrew/OrderedCompatibility:
+  Description: 'This cop checks for compatibility values that are not in alphabetical order.'
+  Enabled: true
+  VersionAdded: '0.0.3'

--- a/lib/rubocop/cop/chromebrew/ordered_compatibility.rb
+++ b/lib/rubocop/cop/chromebrew/ordered_compatibility.rb
@@ -1,0 +1,39 @@
+module RuboCop
+  module Cop
+    module Chromebrew
+      # Compatibility values should be in alphabetic order.
+      #
+      # @example
+      #   # bad
+      #   compatibility 'x86_64 aarch64 armv7l'
+      #
+      #   # good
+      #   compatibility 'aarch64 armv7l x86_64'
+      #
+      class OrderedCompatibility < Base
+        extend AutoCorrector
+        MSG = 'Compatibility values should be in alphabetical order.'
+
+        def_node_matcher :compatibility?, <<~PATTERN
+          (send nil? :compatibility
+            (str $_))
+        PATTERN
+
+        def on_send(node)
+          # Check that we're operating on the compatibility property.
+          value = compatibility?(node)
+          return unless value
+
+          sorted_value = value.split.sort.join(' ')
+
+          return if sorted_value == value
+
+          # If requested, replace the offending compatibility value with the sorted version.
+          add_offense(node.children.last) do |corrector|
+            corrector.replace(node.children.last, "'#{sorted_value}'")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chromebrew_cops.rb
+++ b/lib/rubocop/cop/chromebrew_cops.rb
@@ -1,1 +1,2 @@
 require_relative 'chromebrew/compatibility_all'
+require_relative 'chromebrew/ordered_compatibility'

--- a/spec/rubocop/cop/chromebrew/ordered_compatibility_spec.rb
+++ b/spec/rubocop/cop/chromebrew/ordered_compatibility_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe RuboCop::Cop::Chromebrew::OrderedCompatibility, :config do
+  it 'registers an offense when compatibiltiy is not in alphabetical order with three elements' do
+    expect_offense(<<~'RUBY')
+      compatibility 'x86_64 aarch64 armv7l'
+                    ^^^^^^^^^^^^^^^^^^^^^^^ Compatibility values should be in alphabetical order.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      compatibility 'aarch64 armv7l x86_64'
+    RUBY
+  end
+
+  it 'registers an offense when compatibiltiy is not in alphabetical order with two elements' do
+    expect_offense(<<~'RUBY')
+      compatibility 'x86_64 i686'
+                    ^^^^^^^^^^^^^ Compatibility values should be in alphabetical order.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      compatibility 'i686 x86_64'
+    RUBY
+  end
+
+  it 'does not register an offense when compatibility is in alphabetical order' do
+    expect_no_offenses(<<~'RUBY')
+      compatibility 'aarch64 armv7l x86_64'
+    RUBY
+  end
+
+  it 'does not register an offense when compatibility is a single architecture' do
+    expect_no_offenses(<<~'RUBY')
+      compatibility 'x86_64'
+    RUBY
+  end
+
+  it 'does not register an offense when compatibility is all' do
+    expect_no_offenses(<<~'RUBY')
+      compatibility 'all'
+    RUBY
+  end
+end


### PR DESCRIPTION
Putting this up as a PR to get people's feedback-- I'm doing this so we have unity in the way we list our compatiblity properties, and alphabetical order makes the most sense to me (and it's also much easier to implement than anything else)

Here is the current situation: (`grep -h -R "compatibility '" ./packages/* | sed 's/#.*//' | sort | uniq -c | sort -n`)
```
...
      1   compatibility 'i686'
      1   compatibility 'x86_64 armv7l aarch64'
      1   compatibility 'x86_64' 
      2   compatibility 'aarch64 armv7l x86_64' 
      2   compatibility 'x86_64 i686'
      9   compatibility 'i686 x86_64'
     30   compatibility 'aarch64 armv7l x86_64'
    125   compatibility 'x86_64'
    592   compatibility 'x86_64 aarch64 armv7l'
   1612   compatibility 'all'
```

Here is it after this cop is applied:
```
...
      1   compatibility 'i686'
      1   compatibility 'x86_64' 
      2   compatibility 'aarch64 armv7l x86_64' 
     11   compatibility 'i686 x86_64'
    125   compatibility 'x86_64'
    623   compatibility 'aarch64 armv7l x86_64'
   1612   compatibility 'all'
```

Once this is merged I'll release a new version, after which I'll run rubocop on the chromebrew tree and PR that to apply this cop treewide. (I'm also waiting on a new rubocop version to release so that I can get the new plugin changes in, so we can move off the old inject method of writing extensions)