### PR TITLE
Add Chromebrew/RedundantVersionAdjustment cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -7,3 +7,8 @@ Chromebrew/OrderedCompatibility:
   Description: 'This cop checks for compatibility values that are not in alphabetical order.'
   Enabled: true
   VersionAdded: '0.0.3'
+
+Chromebrew/RedundantVersionAdjustment:
+  Description: 'This cop checks for version adjustments that do not actually change the version.'
+  Enabled: true
+  VersionAdded: '0.0.5'

--- a/lib/rubocop/cop/chromebrew/redundant_version_adjustment.rb
+++ b/lib/rubocop/cop/chromebrew/redundant_version_adjustment.rb
@@ -1,0 +1,71 @@
+module RuboCop
+  module Cop
+    module Chromebrew
+      # Adjustments to the version should change the version.
+      #
+      # @example
+      #   # good
+      #   version '1.0.0-1'
+      #   git_hashtag version.split('-').first
+      #
+      #   # bad
+      #   version '2.3'
+      #   git_hashtag version.split('-').first
+      #
+      #   # good
+      #   version '2.3'
+      #   git_hashtag version
+      #
+      class RedundantVersionAdjustment < Base
+        extend AutoCorrector
+        MSG = 'This version adjustment does not actually change the version.'
+
+        def_node_matcher :version_adjustment?, <<~PATTERN
+          (send `(send nil? :version) ...)
+        PATTERN
+
+        def_node_matcher :find_package_version?, <<~PATTERN
+          (class (const nil? $_) (const nil? {:Autotools | :CMake | :Meson | :PERL | :Package | :Pip | :Python | :Qmake | :RUBY | :RUST}) `(send nil? :version (str $_)))
+        PATTERN
+
+        @@mappings = {}
+
+        # Find and store the original version variable of this package.
+        def on_class(node)
+          return unless find_package_version?(node)
+
+          package, version = find_package_version?(node)
+
+          @@mappings[package] = version
+        end
+
+        def on_send(node)
+          # We're only interested in nodes that are working with the version variable.
+          return unless version_adjustment?(node)
+
+          # Ensure the node we're processing here is a version adjustment in the format we expect.
+          return unless node.source.start_with?('version')
+
+          # Retrieve the original version variable of this package.
+          original_version = @@mappings[node.parent_module_name&.to_sym]
+          return if original_version.nil?
+
+          # Some packages, such as gcc_lib, use version constants from other packages (gcc_build, in this case).
+          # These packages are rare enough that it isn't worth the added complexity that loading those dependent packages would create,
+          # so here we just catch and ignore the NameError that results from evaluating the external version constants.
+          begin
+            # Check if the modifications in this node actually change the version of the package.
+            return unless eval(node.source.sub('version', "'" + original_version + "'")) == original_version
+          rescue NameError
+            return
+          end
+
+          # If this node doesn't actually modify the version, remove every part of it apart from the literal 'version' at the start of it.
+          add_offense(node.source_range.adjust(begin_pos: 'version'.length)) do |corrector|
+            corrector.remove(node.source_range.adjust(begin_pos: 'version'.length))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/chromebrew_cops.rb
+++ b/lib/rubocop/cop/chromebrew_cops.rb
@@ -1,2 +1,3 @@
 require_relative 'chromebrew/compatibility_all'
 require_relative 'chromebrew/ordered_compatibility'
+require_relative 'chromebrew/redundant_version_adjustment'

--- a/spec/rubocop/cop/chromebrew/redundant_version_adjustment_spec.rb
+++ b/spec/rubocop/cop/chromebrew/redundant_version_adjustment_spec.rb
@@ -1,0 +1,145 @@
+RSpec.describe RuboCop::Cop::Chromebrew::RedundantVersionAdjustment, :config do
+  it 'does not register an offense when the version is never used after creation' do
+    expect_no_offenses(<<~'RUBY')
+      class Foo < Package
+        version '0.2.11'
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when not in a package or buildsystem' do
+    expect_no_offenses(<<~'RUBY')
+      class Foobark < Banannas
+        version '0.2.11'
+        git_hashtag version.delete_prefix('release-')
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when the version is not modified' do
+    expect_no_offenses(<<~'RUBY')
+      class Bar < Package
+        version '72a'
+        git_hashtag version
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when the version is not modified inside an interpolated string' do
+    expect_no_offenses(<<~'RUBY')
+      class Florb < Package
+        version '3.h.1'
+        git_hashtag "v#{version}"
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when external version constants are used' do
+    expect_no_offenses(<<~'RUBY')
+      class Gcc_lib < Package
+        version '15.2.0'
+        license Gcc_build.license
+
+        puts "#{self} version (#{version}) differs from gcc version #{Gcc_build.version}".orange if version != Gcc_build.version
+      end
+    RUBY
+  end
+
+
+  it 'does not register an offense when the version is usefully modified inside an interpolated string' do
+    expect_no_offenses(<<~'RUBY')
+      class Flop < Package
+        version '1.2.a'
+
+        git_hashtag "v#{version.rpartition('.')[0]}"
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when the version is usefully modified inside an interpolated string in an install_extras block' do
+    expect_no_offenses(<<~'RUBY')
+      class Gettext < Autotools
+        version '1.0-1'
+
+        autotools_install_extras do
+          downloader "https://github.com/autotools-mirror/gettext/raw/refs/tags/v#{version.split('-')[0]}/gettext-tools/autotools/archive.dir.tar", 'e32c5de9b39a70092e9a82e83ebffb4c0a8c698cf3acbdcbb4902dfebdf767f8', "#{CREW_DEST_PREFIX}/share/gettext/archive.dir.tar"
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the version is uselessly modified' do
+    expect_offense(<<~'RUBY')
+      class Greb < CMake
+        version '0.2.12'
+        git_hashtag version.delete_prefix('release-')
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ This version adjustment does not actually change the version.
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      class Greb < CMake
+        version '0.2.12'
+        git_hashtag version
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the version is uselessly modified inside an interpolated string' do
+    expect_offense(<<~'RUBY')
+      class Qux < Package
+        version '123'
+        git_hashtag "v#{version.split('-').first}"
+                               ^^^^^^^^^^^^^^^^^ This version adjustment does not actually change the version.
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      class Qux < Package
+        version '123'
+        git_hashtag "v#{version}"
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the version is uselessly modified in a buildsystem' do
+    expect_offense(<<~'RUBY')
+      class Quux < CMake
+        version '4.0.10'
+        git_hashtag "R#{version.gsub('-', '_')}"
+                               ^^^^^^^^^^^^^^^ This version adjustment does not actually change the version.
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      class Quux < CMake
+        version '4.0.10'
+        git_hashtag "R#{version}"
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the version is uselessly modified inside a complex interpolated string' do
+    expect_offense(<<~'RUBY')
+      class Fleep < Package
+        version '0.2.11'
+        git_hashtag version
+
+        FileUtils.ln_sf "#{CREW_LIB_PREFIX}/wx/config/gtk3-unicode-#{version.split('-')[0].sub(/\.\d+$/, '')}", "#{CREW_DEST_PREFIX}/bin/wx-config"
+                                                                            ^^^^^^^^^^^^^^ This version adjustment does not actually change the version.
+        FileUtils.ln_sf "#{CREW_PREFIX}/bin/wxrc-#{version.split('-')[0].sub(/\.\d+$/, '')}", "#{CREW_DEST_PREFIX}/bin/wxrc"
+                                                          ^^^^^^^^^^^^^^ This version adjustment does not actually change the version.
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      class Fleep < Package
+        version '0.2.11'
+        git_hashtag version
+
+        FileUtils.ln_sf "#{CREW_LIB_PREFIX}/wx/config/gtk3-unicode-#{version.sub(/\.\d+$/, '')}", "#{CREW_DEST_PREFIX}/bin/wx-config"
+        FileUtils.ln_sf "#{CREW_PREFIX}/bin/wxrc-#{version.sub(/\.\d+$/, '')}", "#{CREW_DEST_PREFIX}/bin/wxrc"
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
The majority of offenses for this cop occur when a revision tag is removed from a package but the `version.split('-').[0]` adjustments aren't removed after.

As you can see:
```
packages/unicode_cldr.rb:10:33: C: [Correctable] Chromebrew/RedundantVersionAdjustment: This version adjustment does not actually change the version.
  git_hashtag "release-#{version.gsub('.', '-')}"
                                ^^^^^^^^^^^^^^^
packages/upx.rb:13:26: C: [Correctable] Chromebrew/RedundantVersionAdjustment: This version adjustment does not actually change the version.
  git_hashtag "v#{version.split('-').first}"
                         ^^^^^^^^^^^^^^^^^
packages/uutils_coreutils.rb:13:22: C: [Correctable] Chromebrew/RedundantVersionAdjustment: This version adjustment does not actually change the version.
  git_hashtag version.split('-').first
                     ^^^^^^^^^^^^^^^^^
packages/xorg_server.rb:10:37: C: [Correctable] Chromebrew/RedundantVersionAdjustment: This version adjustment does not actually change the version.
  git_hashtag "xorg-server-#{version.split('-').first}"
                                    ^^^^^^^^^^^^^^^^^
packages/xwayland.rb:10:34: C: [Correctable] Chromebrew/RedundantVersionAdjustment: This version adjustment does not actually change the version.
  git_hashtag "xwayland-#{version.split('-').first}"
                                 ^^^^^^^^^^^^^^^^^
packages/zlib_ng.rb:13:22: C: [Correctable] Chromebrew/RedundantVersionAdjustment: This version adjustment does not actually change the version.
  git_hashtag version.split('-').first
                     ^^^^^^^^^^^^^^^^^

2683 files inspected, 59 offenses detected, 59 offenses autocorrectable
```

I'll handle a new release personally after this is merged.